### PR TITLE
Add enum role for User on model and database with indexing

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
+#  role                   :enum             default("simple")
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #
@@ -18,8 +19,10 @@
 #
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_role                  (role)
 #
 class User < ApplicationRecord
+  enum role: { simple: 'simple', admin: 'admin' }
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,8 @@
 #  index_users_on_role                  (role)
 #
 class User < ApplicationRecord
-  enum role: { simple: 'simple', admin: 'admin' }
+  enum role: { simple: "simple", admin: "admin"}
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,5 +34,6 @@ module TheBestApp
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+    config.active_record.schema_format = :sql
   end
 end

--- a/db/migrate/20210730130406_add_role_to_users.rb
+++ b/db/migrate/20210730130406_add_role_to_users.rb
@@ -1,0 +1,17 @@
+class AddRoleToUsers < ActiveRecord::Migration[6.1]
+  enable_extension "plpgsql"
+  def up
+    execute <<-SQL
+      CREATE TYPE user_role AS ENUM ('simple', 'admin');
+    SQL
+    add_column :users, :role, :user_role, default: 'simple'
+    add_index :users, :role
+  end
+
+  def down
+    remove_column :users, :role
+    execute <<-SQL
+      DROP TYPE user_role;
+    SQL
+  end
+end

--- a/db/migrate/20210802094348_add_role_to_user.rb
+++ b/db/migrate/20210802094348_add_role_to_user.rb
@@ -1,10 +1,11 @@
-class AddRoleToUsers < ActiveRecord::Migration[6.1]
+class AddRoleToUser < ActiveRecord::Migration[6.1]
   enable_extension "plpgsql"
+   
   def up
     execute <<-SQL
       CREATE TYPE user_role AS ENUM ('simple', 'admin');
     SQL
-    add_column :users, :role, :user_role, default: 'simple'
+    add_column :users, :role, :user_role, default: "simple"
     add_index :users, :role
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_30_130406) do
+ActiveRecord::Schema.define(version: 2021_08_02_094348) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,24 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_28_115116) do
+ActiveRecord::Schema.define(version: 2021_07_30_130406) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "users", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.string "first_name"
-    t.string "last_name"
-    t.integer "phone_number"
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-  end
+# Could not dump table "users" because of following StandardError
+#   Unknown type 'user_role' for column 'role'
 
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,0 +1,149 @@
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: user_role; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.user_role AS ENUM (
+    'simple',
+    'admin'
+);
+
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ar_internal_metadata (
+    key character varying NOT NULL,
+    value character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.schema_migrations (
+    version character varying NOT NULL
+);
+
+
+--
+-- Name: users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.users (
+    id bigint NOT NULL,
+    email character varying DEFAULT ''::character varying NOT NULL,
+    encrypted_password character varying DEFAULT ''::character varying NOT NULL,
+    reset_password_token character varying,
+    reset_password_sent_at timestamp without time zone,
+    remember_created_at timestamp without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    first_name character varying,
+    last_name character varying,
+    phone_number integer,
+    role public.user_role DEFAULT 'simple'::public.user_role
+);
+
+
+--
+-- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.users_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
+
+
+--
+-- Name: users id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
+
+
+--
+-- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ar_internal_metadata
+    ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
+
+
+--
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_users_on_email ON public.users USING btree (email);
+
+
+--
+-- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_users_on_reset_password_token ON public.users USING btree (reset_password_token);
+
+
+--
+-- Name: index_users_on_role; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_users_on_role ON public.users USING btree (role);
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+SET search_path TO "$user", public;
+
+INSERT INTO "schema_migrations" (version) VALUES
+('20210728104235'),
+('20210728115116'),
+('20210802094348');
+
+


### PR DESCRIPTION
Users can now be identified according to their role ("simple" for regular user and "admin" for admins). 